### PR TITLE
Added Initial support for HighDPI Displays

### DIFF
--- a/TrackballScroll/Sources/MainForm.cs
+++ b/TrackballScroll/Sources/MainForm.cs
@@ -25,10 +25,13 @@ namespace TrackballScroll
         private NotifyIcon trayIcon;
         private MenuItem itemEnabled;
         private MenuItem itemPreferAxis;
-        private MouseHookTrackballScroll mouseHook = new MouseHookTrackballScroll();
+        private MouseHookTrackballScroll mouseHook;
 
         public MainForm()
         {
+            var scalingFactor = GetScalingFactor();
+            mouseHook = new MouseHookTrackballScroll(scalingFactor);
+
             itemEnabled = new MenuItem(Properties.Resources.TextButtonHookEnabled, OnToggleHook);
             itemEnabled.Checked = true;
 
@@ -97,6 +100,17 @@ namespace TrackballScroll
         {
             mouseHook.Unhook();
             Application.Exit();
+        }
+        private float GetScalingFactor()
+        {
+            Graphics g = Graphics.FromHwnd(IntPtr.Zero);
+            IntPtr desktop = g.GetHdc();
+            int logicalScreenHeight = NativeMethods.GetDeviceCaps(desktop, (int)WinAPI.DeviceCap.VERTRES);
+            int physicalScreenHeight = NativeMethods.GetDeviceCaps(desktop, (int)WinAPI.DeviceCap.DESKTOPVERTRES);
+
+            float ScreenScalingFactor = (float)physicalScreenHeight / (float)logicalScreenHeight;
+
+            return ScreenScalingFactor; // 1.25 = 125%
         }
 
         protected override void Dispose(bool isDisposing)

--- a/TrackballScroll/Sources/MouseHookTrackballScroll.cs
+++ b/TrackballScroll/Sources/MouseHookTrackballScroll.cs
@@ -27,6 +27,12 @@ namespace TrackballScroll
         WinAPI.POINT _origin;         // cursor position when entering state DOWN
         int _xcount = 0;       // accumulated horizontal movement while in state SCROLL
         int _ycount = 0;       // accumulated vertical movement while in state SCROLL
+        private readonly float _scalingFactor;
+
+        public MouseHookTrackballScroll(float scalingFactor)
+        {
+            _scalingFactor = scalingFactor;
+        }
 
         public override IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
         {
@@ -89,7 +95,11 @@ namespace TrackballScroll
                         preventCallNextHookEx = true;
                         _xcount += p.pt.x - _origin.x;
                         _ycount += p.pt.y - _origin.y;
-                        NativeMethods.SetCursorPos(_origin.x, _origin.y);
+
+                        var originXScaled = (int)(_origin.x / _scalingFactor);
+                        var originYScaled = (int) (_origin.y / _scalingFactor);
+
+                        NativeMethods.SetCursorPos(originXScaled, originYScaled);
                         if (_xcount < -X_THRESHOLD || _xcount > X_THRESHOLD)
                         {
                             uint mouseData = (uint)(_xcount > 0 ? +WinAPI.WHEEL_DELTA : -WinAPI.WHEEL_DELTA); // scroll direction
@@ -111,6 +121,7 @@ namespace TrackballScroll
                             }
                             NativeMethods.SendInput((uint)input.Length, input, Marshal.SizeOf(typeof(WinAPI.INPUT)));
                         }
+
                         if (_ycount < -Y_THRESHOLD || _ycount > Y_THRESHOLD)
                         {
                             uint mouseData = (uint)(_ycount > 0 ? -WinAPI.WHEEL_DELTA : +WinAPI.WHEEL_DELTA); // scroll direction

--- a/TrackballScroll/Sources/NativeMethods.cs
+++ b/TrackballScroll/Sources/NativeMethods.cs
@@ -30,5 +30,8 @@ namespace TrackballScroll
 
         [DllImport("user32.dll", CharSet = CharSet.Unicode, SetLastError = true, ThrowOnUnmappableChar = true)]
         public static extern bool SetCursorPos(int X, int Y);
+
+        [DllImport("gdi32.dll")]
+        public static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
     }
 }

--- a/TrackballScroll/Sources/WinAPI.cs
+++ b/TrackballScroll/Sources/WinAPI.cs
@@ -65,5 +65,11 @@ namespace TrackballScroll
             public uint time;
             public IntPtr dwExtraInfo;
         }
+
+        public enum DeviceCap
+        {
+            VERTRES = 10,
+            DESKTOPVERTRES = 117,
+        }
     }
 }


### PR DESCRIPTION
There is an issue with the way that scaling works in HighDPI displays, 

Because the display is virtualized the x and y coordinates will not play nice with the current code.
The patch gets the scaling factor and factors it out of the X and Y coordinates when scrolling,
by doing this, the cursor doesn't jump to the virtual X and Y and the scroll calculation works correctly.

I tested it with a scaling factor of 100% 125% 150% and 200% and it worked for me.
To reproduce go to the Display Settings Page in Windows 10 and change the scale factor.

It's an initial fix, because it probably needs to do this at runtime, right now it only does it the first time it runs.