### PR TITLE
Fix issue #14: add timer to throttle mouse movements

### DIFF
--- a/TrackballScroll/Sources/MainForm.cs
+++ b/TrackballScroll/Sources/MainForm.cs
@@ -109,6 +109,7 @@ namespace TrackballScroll
         {
             if (isDisposing)
             {
+                mouseHook.Dispose();
                 trayIcon.Dispose();
             }
 


### PR DESCRIPTION
Related to issue #14 
Adding a timer of 1ms seems to fix the issue of the mouse becoming unresponsive and crashing.