### PR TITLE
Use right button as scroll wheel emulation modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ TrackballScroll
 ===============
 **Allow scrolling with a trackball without scroll wheel by using a low level mouse hook.**
 
-Changes the behaviour of one or both X-Buttons (typically buttons 3, 4) to
-- Scrolling, i.e. vertical/horizontal mouse wheel events, when an X-Button is pressed and the trackball is moved vertically/horizontally
+Changes the behaviour of one X-Buttons or right click button (typically buttons 2, 3, 4) to
+- Scrolling, i.e. vertical/horizontal mouse wheel events, when an X/right-Button is pressed and the trackball is moved vertically/horizontally
 - Middle button click, when an X-Button is pressed and released without trackball movement
 
 ###### Requirements
-- A trackball or mouse with X-Buttons
+- A trackball or mouse
 - A Microsoft Windows x64 operating system with .NET 4.5.2
 
 This software has been tested with a *Logitech Marble Trackball*(tm) and *Microsoft Windows 10*.
@@ -30,6 +30,7 @@ https://github.com/Seelge/TrackballScroll/releases/latest
 - Build the solution
 
 ###### Version history
+- v5 allow to use right (context menu) button to enable scroll emulation
 - v4 prevents #16... sort of (middle clicks can be disabled if necessary using the tray menu).
 - v3 feature #12: Allows to choose which X-buttons are used and saves the settings. Also changed versioning scheme to single numbers.
 - v2.1.2 fixes #14. Compatibility with Windows 10 versions of 2017.

--- a/TrackballScroll/App.config
+++ b/TrackballScroll/App.config
@@ -22,6 +22,9 @@
             <setting name="emulateMiddleButton" serializeAs="String">
                 <value>True</value>
             </setting>
+            <setting name="useRButton" serializeAs="String">
+                <value>True</value>
+            </setting>
         </TrackballScroll.Properties.Settings>
     </userSettings>
 </configuration>

--- a/TrackballScroll/App.config
+++ b/TrackballScroll/App.config
@@ -23,7 +23,7 @@
                 <value>True</value>
             </setting>
             <setting name="useRButton" serializeAs="String">
-                <value>True</value>
+                <value>False</value>
             </setting>
         </TrackballScroll.Properties.Settings>
     </userSettings>

--- a/TrackballScroll/Properties/Resources.Designer.cs
+++ b/TrackballScroll/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace TrackballScroll.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -112,6 +112,15 @@ namespace TrackballScroll.Properties {
         internal static string TextButtonHookEnabled {
             get {
                 return ResourceManager.GetString("TextButtonHookEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use right (context menu) button to scroll.
+        /// </summary>
+        internal static string TextButtonHookUseRButton {
+            get {
+                return ResourceManager.GetString("TextButtonHookUseRButton", resourceCulture);
             }
         }
         

--- a/TrackballScroll/Properties/Resources.resx
+++ b/TrackballScroll/Properties/Resources.resx
@@ -162,4 +162,7 @@ https://github.com/Seelge/TrackballScroll/blob/master/LICENSE</value>
   <data name="TextButtonEmulateMiddleButton" xml:space="preserve">
     <value>Emulate middle button when not scrolling</value>
   </data>
+  <data name="TextButtonHookUseRButton" xml:space="preserve">
+    <value>Use right (context menu) button to scroll</value>
+  </data>
 </root>

--- a/TrackballScroll/Properties/Settings.Designer.cs
+++ b/TrackballScroll/Properties/Settings.Designer.cs
@@ -73,7 +73,7 @@ namespace TrackballScroll.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool useRButton {
             get {
                 return ((bool)(this["useRButton"]));

--- a/TrackballScroll/Properties/Settings.Designer.cs
+++ b/TrackballScroll/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace TrackballScroll.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "12.0.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -68,6 +68,18 @@ namespace TrackballScroll.Properties {
             }
             set {
                 this["emulateMiddleButton"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool useRButton {
+            get {
+                return ((bool)(this["useRButton"]));
+            }
+            set {
+                this["useRButton"] = value;
             }
         }
     }

--- a/TrackballScroll/Properties/Settings.settings
+++ b/TrackballScroll/Properties/Settings.settings
@@ -14,5 +14,8 @@
     <Setting Name="emulateMiddleButton" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="useRButton" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/TrackballScroll/Properties/Settings.settings
+++ b/TrackballScroll/Properties/Settings.settings
@@ -15,7 +15,7 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="useRButton" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
   </Settings>
 </SettingsFile>

--- a/TrackballScroll/Sources/MainForm.cs
+++ b/TrackballScroll/Sources/MainForm.cs
@@ -29,6 +29,7 @@ namespace TrackballScroll
         private MenuItem itemEnabled;
         private MenuItem itemUseX1;
         private MenuItem itemUseX2;
+        private MenuItem itemUseRButton;
         private MenuItem itemPreferAxis;
         private MenuItem itemEmulateMiddleButton;
         private MouseHookTrackballScroll mouseHook;
@@ -54,6 +55,11 @@ namespace TrackballScroll
             itemUseX2.Checked = useX2;
             mouseHook.useX2   = useX2;
 
+            var useRButton = Properties.Settings.Default.useRButton;
+            itemUseRButton = new MenuItem(Properties.Resources.TextButtonHookUseRButton, OnToggleUseRButton);
+            itemUseRButton.Checked = useRButton;
+            mouseHook.useRButton = useRButton;
+
             var preferAxis = Properties.Settings.Default.preferAxis;
             itemPreferAxis = new MenuItem(Properties.Resources.TextButtonPreferAxisEnabled, OnToggleAxis);
             itemPreferAxis.Checked = preferAxis;
@@ -68,6 +74,7 @@ namespace TrackballScroll
             trayMenu.MenuItems.Add(itemEnabled);
             trayMenu.MenuItems.Add(itemUseX1);
             trayMenu.MenuItems.Add(itemUseX2);
+            trayMenu.MenuItems.Add(itemUseRButton);
             trayMenu.MenuItems.Add(itemPreferAxis);
             trayMenu.MenuItems.Add(itemEmulateMiddleButton);
             trayMenu.MenuItems.Add(Properties.Resources.TextButtonAbout, OnAbout);
@@ -120,10 +127,6 @@ namespace TrackballScroll
             mouseHook.useX1 = useX1;
             Properties.Settings.Default.useX1 = useX1;
             Properties.Settings.Default.Save();
-            if (!itemUseX1.Checked && !itemUseX2.Checked)
-            {
-                OnToggleUseX2(null, null);
-            }
         }
 
         private void OnToggleUseX2(object sender, EventArgs e)
@@ -132,10 +135,14 @@ namespace TrackballScroll
             mouseHook.useX2 = itemUseX2.Checked;
             Properties.Settings.Default.useX2 = itemUseX2.Checked;
             Properties.Settings.Default.Save();
-            if (!itemUseX1.Checked && !itemUseX2.Checked)
-            {
-                OnToggleUseX1(null, null);
-            }
+        }
+
+        private void OnToggleUseRButton(object sender, EventArgs e)
+        {
+            itemUseRButton.Checked = !itemUseRButton.Checked;
+            mouseHook.useRButton = itemUseRButton.Checked;
+            Properties.Settings.Default.useRButton = itemUseRButton.Checked;
+            Properties.Settings.Default.Save();
         }
 
         private void OnToggleAxis(object sender, EventArgs e)

--- a/TrackballScroll/Sources/MouseHookTrackballScroll.cs
+++ b/TrackballScroll/Sources/MouseHookTrackballScroll.cs
@@ -29,8 +29,10 @@ namespace TrackballScroll
         const uint WHEEL_FACTOR = 1; // number of wheel events. The lines scrolled per wheel event are determined by the Microsoft Windows mouse wheel settings.
 
         public bool preferAxisMovement { get; set; }
+#if DEBUG
         private NLog.ILogger _log;
         private NLog.ILogger log { get { return _log; } }
+#endif
         private System.Timers.Timer timer { get; set; }
         public bool useX1 { get; set; }
         public bool useX2 { get; set; }

--- a/TrackballScroll/Sources/MouseHookTrackballScroll.cs
+++ b/TrackballScroll/Sources/MouseHookTrackballScroll.cs
@@ -29,7 +29,8 @@ namespace TrackballScroll
         const uint WHEEL_FACTOR = 1; // number of wheel events. The lines scrolled per wheel event are determined by the Microsoft Windows mouse wheel settings.
 
         public bool preferAxisMovement { get; set; }
-        private NLog.ILogger log { get; }
+        private NLog.ILogger _log;
+        private NLog.ILogger log { get { return _log; } }
         private System.Timers.Timer timer { get; set; }
         public bool useX1 { get; set; }
         public bool useX2 { get; set; }
@@ -61,7 +62,7 @@ namespace TrackballScroll
                 timer.Enabled = false;
             };
 #if DEBUG
-            log = new NLog.ILogger();
+            _log = new NLog.ILogger();
 #endif
         }
 

--- a/TrackballScroll/Sources/WinAPI.cs
+++ b/TrackballScroll/Sources/WinAPI.cs
@@ -20,7 +20,9 @@ namespace TrackballScroll
         {
             WM_MOUSEMOVE = 0x0200,
             WM_XBUTTONDOWN = 0x020B,
-            WM_XBUTTONUP = 0x020C
+            WM_XBUTTONUP = 0x020C,
+            WM_RBUTTONDOWN = 0x0204,
+            WM_RBUTTONUP = 0x0205
         }
 
         public enum MouseEvent : uint


### PR DESCRIPTION
I use Logitech Marble trackball on Ubuntu for about 4 years. By editing /etc/X11/xorg.conf.d/10-libinput.conf I configured trackball so right (context menu) button enables scroll emulation mode.

Right button is much easier accessible than X-Buttons, so I accustomed myself to that configuration. 

Now I have to switch to Windows 10 and found your great software to emulate scroll wheel on logitech marble. I added to it a feature, so right button also can be used as emulation mode enabler.